### PR TITLE
Improve performance of in-container commands with many write on disks

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,3 +14,5 @@ RUN apt-get update && apt-get -y install --no-install-recommends java-common zip
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 ENV DEBIAN_FRONTEND=dialog
+
+WORKDIR /workspaces

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,11 +19,11 @@
 	],
 
 	// Use in-container folder (not mounted host directory) as a workspace to speeeeeeed-up the `npx create-react-app` command. See https://github.com/toricls/aws-amplify-sns-workshop-in-vscode/pull/3.
-	"workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/hostdir,type=bind,consistency=cached",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/hostdir,type=bind,consistency=cached",
 	"workspaceFolder": "/workspaces",
 	"containerEnv": { 
 		"MOUNTED_HOST_DIR": "${localWorkspaceFolder}",
-		"MOUNTED_HOST_DIR_PATH_IN_CONTAINER": "/workspaces/hostdir"
+		"MOUNTED_HOST_DIR_PATH_IN_CONTAINER": "/hostdir"
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,6 +18,14 @@
 		"source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws,target=/root/.aws,type=bind,consistency=cached"
 	],
 
+	// Use in-container folder (not mounted host directory) as a workspace to speeeeeeed-up the `npx create-react-app` command. See https://github.com/toricls/aws-amplify-sns-workshop-in-vscode/pull/3.
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/hostdir,type=bind,consistency=cached",
+	"workspaceFolder": "/workspaces",
+	"containerEnv": { 
+		"MOUNTED_HOST_DIR": "${localWorkspaceFolder}",
+		"MOUNTED_HOST_DIR_PATH_IN_CONTAINER": "/workspaces/hostdir"
+	},
+
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [3000,20002],
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 With using the VSCode's remote container extension and the files in this repo, you can walk through the [Amplify SNS Workshop](https://amplify-sns.workshop.aws/) without installing (unwanted) stuff into your local machine's environment.
 
-We created and tested this repo on/for macOS, but it also could work on Windows machines 田ミ
+We've created and tested this repo on/for macOS, but it also could work on Windows machines 田ミ
 
 ## Prerequisities
 
@@ -18,37 +18,56 @@ We created and tested this repo on/for macOS, but it also could work on Windows 
 
 ## Structure
 
-```
+### Repository
+
+```shell
 .
 ├── .devcontainer <- Configs for the 'Remote - Containers' extension
 ├── .gitignore
+├── copy-boyaki-to-host.sh <- See the "Note" below
 ├── LICENSE
-├── README.md     <- This file :)
-└── boyaki        <- An empty directory for the app created in the workshop
+└── README.md              <- You're reading this file right now :)
 ```
+
+### In the remote container
+
+```shell
+.
+└── hostdir <- Contains all files and folders in this repository
+```
+
+#### Preserving your work
+
+**_NOTE: You will find the `boyaki` directory in your remote container during the workshop (so as in the VSCode's explorer) but NOT in your host machine. This is a side-effect of the fix PR [#3](https://github.com/toricls/aws-amplify-sns-workshop-in-vscode/pull/3) (for the issue [#2](https://github.com/toricls/aws-amplify-sns-workshop-in-vscode/issues/2)) to speed up the `npx create-react-app` command, thus you may lose your `boyaki` files once you stop the remote container. If you need to preserve and/or edit the files inside the `boyaki` folder outside of your remote container, you can use the bash script `copy-boyaki-to-host.sh` to copy those in-container files as a zip file `boyaki.zip` to your host machine's `boyaki` directory. Simply execute `/workspaces/hostdir/copy-boyaki-to-host.sh` inside your remote container and follow the guidance to run it._**
 
 ## Details of the container
 
 ### 1. Installed Packages
 
-#### via `.devcontainer/Dockerfile`.
+#### via `.devcontainer/Dockerfile`
 
 - Node.js v12.x
 - AWS CLI v2.x
 - Amazon Corretto 8 (OpenJDK 1.8.x) _for the "Amplify Mocking" feature_
 
-#### via `.devcontainer/devcontainer.json`.
+#### via `.devcontainer/devcontainer.json`
 
 - AWS Amplify CLI 4.16.1
 
-### 2. Configurations
+### 2. Default configurations
 
-#### Mounted directories
+_We'd recommend you to use this repository with the default configurations below, but still you can change the configs in the `devcontainer.json` file and/or the `Dockerfile` in the `.devcontainer` directory if you need._
 
-- Your workspace folder (= the cloned folder itself)
+#### Working directory (inside your remote container)
+
+- `/workspaces`
+
+#### Mounted directories (to your remote container)
+
+- Your git cloned folder (as `/workspaces/host` in the container)
 - Your AWS credentials folder ({$HOME|$USERPROFILE}/.aws). So that you can use your existing AWS profiles for the `amplify init` command, and you don't need to run the `amplify configure` command if you use your pre-configured AWS profile.
 
-#### Forwarded Ports
+#### Forwarded Ports (from host to your remote container)
 
 The following ports are exposed from the remote container and you can access them via your web browser with http://localhost:{PORT_NUMBER}.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ We've created and tested this repo on/for macOS, but it also could work on Windo
 
 ```shell
 .
-├── .devcontainer <- Configs for the 'Remote - Containers' extension
+├── .devcontainer          <- Configs for the 'Remote - Containers' extension
 ├── .gitignore
 ├── copy-boyaki-to-host.sh <- See the "Note" below
 ├── LICENSE
@@ -32,13 +32,16 @@ We've created and tested this repo on/for macOS, but it also could work on Windo
 ### In the remote container
 
 ```shell
-.
-└── hostdir <- Contains all files and folders in this repository
+/              <- Container's root
+...
+├── hostdir    <- Mounted host directory (= containers all files and folders of this repository)
+...
+└── workspaces <- Your working directory :)
 ```
 
 #### Preserving your work
 
-**_NOTE: You will find the `boyaki` directory in your remote container during the workshop (so as in the VSCode's explorer) but NOT in your host machine. This is a side-effect of the fix PR [#3](https://github.com/toricls/aws-amplify-sns-workshop-in-vscode/pull/3) (for the issue [#2](https://github.com/toricls/aws-amplify-sns-workshop-in-vscode/issues/2)) to speed up the `npx create-react-app` command, thus you may lose your `boyaki` files once you stop the remote container. If you need to preserve and/or edit the files inside the `boyaki` folder outside of your remote container, you can use the bash script `copy-boyaki-to-host.sh` to copy those in-container files as a zip file `boyaki.zip` to your host machine's `boyaki` directory. Simply execute `/workspaces/hostdir/copy-boyaki-to-host.sh` inside your remote container and follow the guidance to run it._**
+**_NOTE: You will find the `boyaki` directory in your remote container during the workshop (so as in the VSCode's explorer) but NOT in your host machine. This is a side-effect of the fix PR [#3](https://github.com/toricls/aws-amplify-sns-workshop-in-vscode/pull/3) (for the issue [#2](https://github.com/toricls/aws-amplify-sns-workshop-in-vscode/issues/2)) to speed up the `npx create-react-app` command, thus you may lose your `boyaki` files once you stop the remote container. If you need to preserve and/or edit the files inside the `boyaki` folder outside of your remote container, you can use the bash script `copy-boyaki-to-host.sh` to copy those in-container files as a zip file `boyaki.zip` to your host machine's `boyaki` directory. Simply execute `/hostdir/copy-boyaki-to-host.sh` inside your remote container and follow the guidance to run it._**
 
 ## Details of the container
 

--- a/copy-boyaki-to-host.sh
+++ b/copy-boyaki-to-host.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -eu
+
+BOYAKI_DIRECTORY=/workspaces/boyaki
+ARCHIVE_NAME=boyaki.zip
+TARGET=${MOUNTED_HOST_DIR_PATH_IN_CONTAINER}/boyaki
+
+
+if [ -f "${TARGET}/${ARCHIVE_NAME}" ]; then
+    echo "We can't override the existing \"${MOUNTED_HOST_DIR}/boyaki/${ARCHIVE_NAME}\" file on your host machine!" 1>&2
+    echo "Remove the file first and re-run again :)" 1>&2
+    exit 2
+fi
+
+echo "Creating an arhive file from \"${BOYAKI_DIRECTORY}\" inside container..."
+cd ${BOYAKI_DIRECTORY}/
+ZIP_FILE="/tmp/${ARCHIVE_NAME}"
+rm -f ${ZIP_FILE} && zip -qr ${ZIP_FILE} ./
+
+echo "Copying the archive file to \"${MOUNTED_HOST_DIR}/boyaki/${ARCHIVE_NAME}\"..."
+mkdir -p ${TARGET}
+cp ${ZIP_FILE} ${TARGET}/${ARCHIVE_NAME}
+
+echo "Done! Yay!"


### PR DESCRIPTION
This PR improves container disk performance for the `npx create-react-app` command and fixes #2 by using in-container storage instead of mounted storage.

As excerpted from the updated README.md as follows, this PR includes a bash script to preserve files from remote container to user's host directory.

---
*NOTE: You will find the `boyaki` directory in your remote container during the workshop (so as in the VSCode's explorer) but NOT in your host machine. This is a side-effect of the fix PR [#3](https://github.com/toricls/aws-amplify-sns-workshop-in-vscode/pull/3) (for the issue [#2](https://github.com/toricls/aws-amplify-sns-workshop-in-vscode/issues/2)) to speed up the `npx create-react-app` command, thus you may lose your `boyaki` files once you stop the remote container. If you need to preserve and/or edit the files inside the `boyaki` folder outside of your remote container, you can use the bash script `copy-boyaki-to-host.sh` to copy those in-container files as a zip file `boyaki.zip` to your host machine's `boyaki` directory. Simply execute ~`/workspaces/hostdir/copy-boyaki-to-host.sh`~ `/hostdir/copy-boyaki-to-host.sh` inside your remote container and follow the guidance to run it.*